### PR TITLE
Fix QTreeView StyleSheet

### DIFF
--- a/bec_qthemes/qss_editor/qss/theme_base.qss
+++ b/bec_qthemes/qss_editor/qss/theme_base.qss
@@ -882,7 +882,6 @@ QTreeView, QTreeWidget {
   border-radius: %%RADIUS_MEDIUM%%;
   outline: 0;
   alternate-background-color: %%CARD_BG%%;
-  indentation: 18px;
 }
 
 QTreeView::item, QTreeWidget::item {


### PR DESCRIPTION
The property indentation is not valid for the QTreeView, this PR removes it to avoid error prints when using QTreeWidget. Please check the example widget below with the old stylesheet, and check the print statements in the shell..
-->
*Unknown property indentation*

```python
from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem


class MyTreeWidget(QTreeWidget):
    def __init__(self, parent=None):
        super().__init__(parent)
        self.setColumnCount(2)
        self.setHeaderLabels(["Name", "Value"])

    def add_item(self, name: str, value: str):
        item = QTreeWidgetItem([name, value])
        self.addTopLevelItem(item)

    def get_item_value(self, name: str) -> str:
        for index in range(self.topLevelItemCount()):
            item = self.topLevelItem(index)
            if item.text(0) == name:
                return item.text(1)
        return ""


if __name__ == "__main__":
    from bec_qthemes import apply_theme
    from qtpy.QtWidgets import QApplication

    app = QApplication([])
    apply_theme("dark")

    tree_widget = MyTreeWidget()
    tree_widget.add_item("Item1", "Value1")
    tree_widget.add_item("Item2", "Value2")
    tree_widget.show()

    print(tree_widget.get_item_value("Item1"))  # Output: Value1
    print(tree_widget.get_item_value("Item3"))  # Output: (empty string)

    app.exec_()

```
